### PR TITLE
Feat: 게시글 삭제기능 구현 및 useEffect 렌더링 문제 해결

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,34 +23,34 @@ function App(props) {
   let dispatch = useDispatch();
   const isLoading = useSelector((state) => state.user.isLoading);
 
-  useEffect(() => {
-    firebase.auth().onAuthStateChanged((user) => {
-      if (user) {
-        // 로그인 시에 채팅페이지로 이동
-        navigate("/chat");
-        dispatch(setUser(user));
-      } else {
-        navigate("/login");
-        dispatch(clearUser());
-      }
-    });
-  }, []);
+  // useEffect(() => {
+  //   firebase.auth().onAuthStateChanged((user) => {
+  //     if (user) {
+  //       // 로그인 시에 채팅페이지로 이동
+  //       navigate("/chat");
+  //       dispatch(setUser(user));
+  //     } else {
+  //       navigate("/login");
+  //       dispatch(clearUser());
+  //     }
+  //   });
+  // }, []);
 
-  if (isLoading) {
-    return <div>로딩중입니다.</div>;
-  } else {
-    return (
-      <Routes>
-        <Route path="/" element={<MainPage />} />
-        <Route path="/chat" element={<ChatPage />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/register" element={<RegisterPage />} />
+  // if (isLoading) {
+  //   return <div>로딩중입니다.</div>;
+  // } else {
+  return (
+    <Routes>
+      <Route path="/" element={<MainPage />} />
+      <Route path="/chat" element={<ChatPage />} />
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
 
-        <Route path="/write" element={<Write />} />
-        <Route path="/board/:id" element={<UniBoard />} />
-      </Routes>
-    );
-  }
+      <Route path="/write" element={<Write />} />
+      <Route path="/board/:id" element={<UniBoard />} />
+    </Routes>
+  );
+  // }
 }
 
 export default App;

--- a/src/Hooks/useDidMountEffect.js
+++ b/src/Hooks/useDidMountEffect.js
@@ -1,0 +1,9 @@
+const { useEffect, useRef } = require("react");
+
+export const useDidMountEffect = (func, deps) => {
+  const didMount = useRef(false);
+  useEffect(() => {
+    if (didMount.current) func();
+    else didMount.current = true;
+  }, deps);
+};

--- a/src/components/MainPage/Body/Board/BoardList.jsx
+++ b/src/components/MainPage/Body/Board/BoardList.jsx
@@ -7,7 +7,7 @@ import { useNavigate } from "react-router-dom";
 function BoardList() {
   const [DBData, setDBData] = useState([]);
   const navigate = useNavigate();
-  console.log(DBData)
+  console.log(DBData);
   useEffect(() => {
     getContents();
   }, []);
@@ -44,7 +44,6 @@ const ContentList = styled.div`
   display: flex;
   flex-direction: column;
   background-color: white;
-  border-top: solid;
   border-bottom: solid;
   border-width: thin;
   border-color: #cccccc;
@@ -69,6 +68,7 @@ const Title = styled.h3`
 const Content = styled.p`
   font-size: 15px;
   width: 100%;
+  height: 50px;
 `;
 
 const Contents = styled.div`

--- a/src/components/MainPage/Body/Board/BoardList.jsx
+++ b/src/components/MainPage/Body/Board/BoardList.jsx
@@ -1,20 +1,30 @@
 import { boardDB } from "../../../../firebase.js";
 import React, { useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
-import { collection, getDocs } from "firebase/firestore";
+import { collection, getDocs, orderBy, query } from "firebase/firestore";
 import { useNavigate } from "react-router-dom";
 
 function BoardList() {
   const [DBData, setDBData] = useState([]);
   const navigate = useNavigate();
-  console.log(DBData);
+
   useEffect(() => {
     getContents();
   }, []);
 
   const getContents = async () => {
-    const dbData = await getDocs(collection(boardDB, "Board"));
-    setDBData(dbData.docs);
+    // const dbData = await getDocs(collection(boardDB, "Board"));
+    // setDBData(dbData.docs);
+
+    const boardRef = query(
+      collection(boardDB, "Board"),
+      orderBy("date", "desc")
+    );
+    const boardSnapshot = await getDocs(boardRef);
+
+    console.log("boardSnapshot", boardSnapshot);
+    setDBData(boardSnapshot.docs);
+    console.log("dbData", DBData[0].id);
   };
 
   const navigateUniBoard = (data) => {

--- a/src/components/MainPage/Body/Board/BoardList.jsx
+++ b/src/components/MainPage/Body/Board/BoardList.jsx
@@ -22,8 +22,6 @@ function BoardList() {
   };
 
   const navigateUniBoard = (id, data) => {
-    console.log("clicked", id);
-    console.log("clicked", data);
     navigate("/board/:id", {
       state: { id: id, data: data },
     });

--- a/src/components/MainPage/Body/Board/BoardList.jsx
+++ b/src/components/MainPage/Body/Board/BoardList.jsx
@@ -13,23 +13,19 @@ function BoardList() {
   }, []);
 
   const getContents = async () => {
-    // const dbData = await getDocs(collection(boardDB, "Board"));
-    // setDBData(dbData.docs);
-
     const boardRef = query(
       collection(boardDB, "Board"),
       orderBy("date", "desc")
     );
     const boardSnapshot = await getDocs(boardRef);
-
-    console.log("boardSnapshot", boardSnapshot);
     setDBData(boardSnapshot.docs);
-    console.log("dbData", DBData[0].id);
   };
 
-  const navigateUniBoard = (data) => {
+  const navigateUniBoard = (id, data) => {
+    console.log("clicked", id);
+    console.log("clicked", data);
     navigate("/board/:id", {
-      state: { data: data },
+      state: { id: id, data: data },
     });
   };
 
@@ -37,9 +33,9 @@ function BoardList() {
     <ContentList style={{ overflow: "scroll" }}>
       {DBData.map((doc) => (
         <Contents
-          key={doc.data().id}
+          key={doc.id}
           onClick={() => {
-            navigateUniBoard(doc.data());
+            navigateUniBoard(doc.id, doc.data());
           }}
         >
           <Title>{doc.data().title}</Title>

--- a/src/components/MainPage/Body/Board/Pagination.jsx
+++ b/src/components/MainPage/Body/Board/Pagination.jsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-function BoardPagination() {
-  return <div></div>;
-}
-
-export default BoardPagination;

--- a/src/components/MainPage/Body/Board/UniBoard.jsx
+++ b/src/components/MainPage/Body/Board/UniBoard.jsx
@@ -7,16 +7,17 @@ import { boardDB } from "../../../../firebase";
 
 function UniBoard() {
   const navigate = useNavigate();
-
   const location = useLocation();
+  const id = location.state.id;
   const data = location.state.data;
-  console.log("unidata", data);
+
   const handleDelelte = async () => {
     console.log("delete");
-    await deleteDoc(doc(boardDB, "Board", "6EU2TEkeFKw6PnUYhqJM"));
+    await deleteDoc(doc(boardDB, "Board", id));
     alert("삭제되었습니다.");
     navigate(-1);
   };
+
   return (
     <div
       style={{

--- a/src/components/MainPage/Body/Board/UniBoard.jsx
+++ b/src/components/MainPage/Body/Board/UniBoard.jsx
@@ -20,44 +20,68 @@ function UniBoard() {
   return (
     <div
       style={{
-        backgroundColor: "aliceblue",
         height: "100vh",
+        backgroundColor: "#fafafae1",
       }}
     >
       <Header />
       <UniBody>
         <UniContents>
           <UniTitle>{data.title}</UniTitle>
-          <button onClick={handleDelelte}>게시물 삭제</button>
+          <UniContent>{data.content}</UniContent>
+          <button
+            style={{
+              alignSelf: "flex-end",
+              marginTop: "500px",
+              width: "fit-content",
+              whiteSpace: "nowrap",
+              textAlign: "center",
+            }}
+            onClick={handleDelelte}
+          >
+            삭제
+          </button>
         </UniContents>
       </UniBody>
     </div>
   );
 }
 
+const UniContent = styled.div`
+  font-size: 18px;
+  margin-top: 20px;
+`;
+
 const UniContents = styled.div`
   display: flex;
   flex-direction: column;
-  background-color: aliceblue;
   width: 905px;
   height: 100%;
-
+  background-color: white;
+  border-radius: 2%;
+  border: solid;
+  border-width: thin;
+  border-color: #cccccc;
   padding: 40px;
 `;
 
 const UniTitle = styled.div`
   font-size: 36px;
+  border-bottom: solid;
+  border-width: thin;
+  border-color: #cccccc;
+  font-weight: 600;
 `;
 
 const UniBody = styled.div`
   display: flex;
   flex-direction: column;
-  background-color: white;
-  height: 100%;
+  padding-top: 50px;
+  background-color: #fafafae1;
+  height: 80%;
   width: 100%;
   margin: 0 auto;
   align-items: center;
-  padding-top: 5%;
   -ms-overflow-style: none; /* 인터넷 익스플로러 */
   scrollbar-width: none; /* 파이어폭스 */
   ::-webkit-scrollbar {

--- a/src/components/MainPage/Body/Board/Write.jsx
+++ b/src/components/MainPage/Body/Board/Write.jsx
@@ -26,11 +26,6 @@ const Write = () => {
     setTitle(e.target.value);
   };
 
-  useEffect(() => {
-    console.log("content", content);
-    createBoard();
-  }, [content]);
-
   // 작성하기 버튼을 누르면 editor의 내용을 content에 저장
   const onSubmit = async (e) => {
     e.preventDefault();
@@ -40,9 +35,8 @@ const Write = () => {
   };
   const uniqueId = Math.random().toString(36).substr(2, 16);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const createBoard = async () => {
-    console.log("title", title);
-    console.log("content", content);
     if (title === "") {
       alert("제목은 필수 입력사항입니다.");
     } else {
@@ -62,6 +56,11 @@ const Write = () => {
       }
     }
   };
+
+  useEffect(() => {
+    console.log("content", content);
+    createBoard();
+  }, [content]);
 
   return (
     <div>

--- a/src/components/MainPage/Body/Board/Write.jsx
+++ b/src/components/MainPage/Body/Board/Write.jsx
@@ -5,8 +5,9 @@ import styled from "styled-components";
 import Header from "components/MainPage/Header/Header";
 import { Editor } from "@toast-ui/react-editor";
 import "@toast-ui/editor/dist/toastui-editor.css";
-import { addDoc, collection, doc, getDocs, setDoc } from "firebase/firestore";
+import { addDoc, collection } from "firebase/firestore";
 import { boardDB } from "../../../../firebase";
+import { useDidMountEffect } from "Hooks/useDidMountEffect";
 
 const Write = () => {
   const navigate = useNavigate();
@@ -15,25 +16,25 @@ const Write = () => {
   const [content, setContent] = useState("");
   const [title, setTitle] = useState("");
 
-  // 뒤로가기 버튼
-  const handleGoBack = useCallback(() => {
-    navigate(-1);
-  }, [navigate]);
-
-  // 제목 입력
-  const handleTitleChange = (e) => {
-    e.preventDefault();
-    setTitle(e.target.value);
-  };
-
   // 작성하기 버튼을 누르면 editor의 내용을 content에 저장
   const onSubmit = async (e) => {
     e.preventDefault();
     const contentMark = editorRef.current?.getInstance().getMarkdown();
     setContent(contentMark);
-    // await createBoard();
   };
-  const uniqueId = Math.random().toString(36).substr(2, 16);
+
+  // useEffect(() => {
+  //   if (content === "") return;
+  //   else {
+  //     console.log("content", content);
+  //     createBoard();
+  //   }
+  // }, [content]);
+
+  useDidMountEffect(() => {
+    console.log("content", content);
+    createBoard();
+  }, [content]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const createBoard = async () => {
@@ -57,10 +58,18 @@ const Write = () => {
     }
   };
 
-  useEffect(() => {
-    console.log("content", content);
-    createBoard();
-  }, [content]);
+  const uniqueId = Math.random().toString(36).substr(2, 16);
+
+  // 뒤로가기 버튼
+  const handleGoBack = useCallback(() => {
+    navigate(-1);
+  }, [navigate]);
+
+  // 제목 입력
+  const handleTitleChange = (e) => {
+    e.preventDefault();
+    setTitle(e.target.value);
+  };
 
   return (
     <div>


### PR DESCRIPTION
close #21 #23 
## Motivation
deleteDoc 메서드를 이용하여 삭제 기능을 구현하였습니다.

## Key Changes
firestore에서 받아온 데이터를 uniboard에 넘겨주는 로직을 수정하였습니다.
### 기존
- navigate의 state를 이용하여 doc.data()를 넘겼습니다. 
- doc.data() 안에는 title, content, date, id가 있습니다. 
- useLocation 훅을 이용하여 location.state 내에 있는 data 값 안에 있는 title과 content를 단독 게시글로 보여주였습니다.

### 현재
- navigate의 state를 이용하여 doc.data()와 추가적으로 doc.id를 넘겼습니다. 
- doc.id는 firestore 컬랙션 내의 문서 id 입니다. 
- id를 location.state로 받아왔고, deleteDoc 메서드에 해당 id를 넣어줘 메인페이지에서 클릭한 게시글을 삭제할 수 있도록 구현하였습니다.

## 스크린샷
![취소기능구현](https://github.com/wldnjs7064/react-firebase-chat-app/assets/108210492/ef3bc104-f649-4003-9575-cbab8193a228)

## To Reviewers
- 방금 구현한 setContent 버그 해결한 줄 알았는데, useEffect 훅이 최초 렌더링시에도 실행되어 새로 Hook을 만들어 사용해야 할 것 같습니다.

