### PR TITLE
Fix: 태그 선택 해제 후 태그의 색이 변하지 않는 오류 해결

### DIFF
--- a/src/components/MainPage/Body/Board/BoardList.jsx
+++ b/src/components/MainPage/Body/Board/BoardList.jsx
@@ -12,12 +12,12 @@ function BoardList() {
   const navigate = useNavigate();
   const selector = useSelector((state) => state.tag.selectedTag);
   const dispatch = useDispatch();
+
   useEffect(() => {
     setSelectTag("");
     Object.keys(selector).forEach((tagKey) => {
       const tag = selector[tagKey];
       if (tag.selected && tag.name !== selectTag) {
-        console.log("tagName", tag.name);
         setSelectTag(tag.name);
       }
     });

--- a/src/components/MainPage/Body/BodyHeader/HeaderFilter/HeaderFilter.jsx
+++ b/src/components/MainPage/Body/BodyHeader/HeaderFilter/HeaderFilter.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import styled from "styled-components";
 import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
@@ -8,12 +8,24 @@ import { selectTag } from "redux/actions/toggle_action";
 function Filtering() {
   const dispatch = useDispatch();
   const usetags = useSelector((state) => state.tag.selectedTag);
+  const [selectedTag, setSelectedTag] = useState("");
+  const selector = useSelector((state) => state.tag.selectedTag);
+
+  useEffect(() => {
+    setSelectedTag("");
+    Object.keys(selector).forEach((tagKey) => {
+      const tag = selector[tagKey];
+      if (tag.selected && tag.name !== selectedTag) {
+        setSelectedTag(tag.name);
+      }
+    });
+  }, [selector]);
+  console.log(selectedTag);
 
   const handleClick = (tags) => {
     usetags.forEach((tag) => {
       if (tag.selected) {
         dispatch(selectTag(tag.name));
-        console.log(tag.name);
       }
     });
     dispatch(selectTag(tags.name));
@@ -27,7 +39,7 @@ function Filtering() {
       {usetags.map((tag) => (
         <Tag
           key={tag.name}
-          selected={tag.selected}
+          selected={tag.name === selectedTag}
           onClick={() => handleClick(tag)}
         >
           #{tag.name}

--- a/src/redux/reducers/tagReducer.js
+++ b/src/redux/reducers/tagReducer.js
@@ -31,6 +31,25 @@ const initialState = {
   ],
 };
 
+// const tagReducer = (state = initialState, action) => {
+//   switch (action.type) {
+//     case SELECT_TAG:
+//       return {
+//         // ...state,
+//         selectedTag: state.selectedTag.map((tag) =>
+//           tag.name === action.payload
+//             ? { ...tag, selected: !tag.selected }
+//             : tag
+//         ),
+//       };
+
+//     default:
+//       return state;
+//   }
+// };
+
+// export default tagReducer;
+
 const tagReducer = (state = initialState, action) => {
   switch (action.type) {
     case SELECT_TAG:
@@ -39,7 +58,7 @@ const tagReducer = (state = initialState, action) => {
         selectedTag: state.selectedTag.map((tag) =>
           tag.name === action.payload
             ? { ...tag, selected: !tag.selected }
-            : tag
+            : { ...tag, selected: false }
         ),
       };
 


### PR DESCRIPTION
## Key Changes
- 태그를 두 번 클릭해도 태그 색이 파란색으로 유지되는 버그를 수정하였습니다.

## 스크린샷
![태그선택버그](https://github.com/wldnjs7064/react-firebase-chat-app/assets/108210492/5954fad9-6229-4c08-97d5-f8ad6f75421e)

